### PR TITLE
feat: implement French typography rule for non-breaking space before percentage

### DIFF
--- a/.claude/DEFINITION_OF_DONE.md
+++ b/.claude/DEFINITION_OF_DONE.md
@@ -1,0 +1,41 @@
+## Definition of Done
+
+A feature is considered complete when:
+
+### ✅ Test-Driven Development
+- [ ] **TDD followed strictly** - test written first, fails, then implementation makes it pass
+- [ ] **Unit tests added** in `tests/FrenchGuidelinesCheckerTest.php`
+- [ ] **Both detection and fixing tested** - error detection AND `--fix` flag behavior
+- [ ] **Edge cases covered** - multiple occurrences, already correct text, false positives
+
+### ✅ Core Implementation
+- [ ] **Feature works as specified** for all typography rules or translation scenarios
+- [ ] **Logic added to correct method** (`processString()` for typography, `glossaryCheck()` for terminology)
+- [ ] **Error messages in French** following existing patterns: `"Message describing issue: $text"`
+- [ ] **Uses existing constants** (`self::NBSP`, `DOUBLE_PUNCTUATION`, `ELLIPSIS`) or adds new ones if needed
+
+### ✅ Code Quality
+- [ ] **All quality checks pass** - `composer qa` (includes cs, stan, test)
+- [ ] **PSR-12 code style** - `composer cs` passes
+- [ ] **PHPStan level 9** - `composer stan` passes with no errors
+- [ ] **No breaking changes** to existing functionality
+- [ ] **Follows existing patterns** in the codebase
+
+### ✅ Documentation
+- [ ] **Rule marked as implemented** - ✅ checked in `docs/french-rules.md`
+- [ ] **README updated if needed** - for major features or new capabilities
+
+
+### ✅ Manual Testing
+- [ ] **CLI tool tested** - `bin/check-translation test-file.po` works correctly
+- [ ] **Error detection works** - warnings/errors show properly
+- [ ] **Fix functionality works** - `--fix` flag applies corrections
+- [ ] **No regressions** - existing rules still work as expected
+
+### ✅ Release Ready
+- [ ] **All tests pass** - `composer test` (28+ tests)
+- [ ] **No PHPStan errors** at level 9
+- [ ] **Code style compliant** with PSR-12
+- [ ] **Ready for production use** in translation workflows
+
+The goal: ship typography rules and translation features that work reliably, and can be maintained easily.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+    "permissions": {
+        "allow": [
+            "Bash(composer test:*)",
+            "Bash(composer cs:*)",
+            "Bash(composer stan:*)"
+        ],
+        "deny": []
+    }
+}

--- a/.github/ISSUE_TEMPLATE/french-typography-rule.md
+++ b/.github/ISSUE_TEMPLATE/french-typography-rule.md
@@ -1,0 +1,54 @@
+---
+name: French Typography Rule Implementation
+about: Implement a specific French typography rule
+title: "Implement French typography rule: [RULE_NAME]"
+labels: enhancement, typography, french-rules, good first issue
+assignees: ''
+---
+
+## Rule Description
+
+**Rule**: [Describe the rule in plain French]
+**Examples**: 
+- ❌ Incorrect: `[bad example]`
+- ✅ Correct: `[good example]`
+
+**Reference**: `docs/french-rules.md` line X (currently unchecked ❌)
+
+## Implementation Requirements
+
+### 1. Test-Driven Development (TDD)
+**MANDATORY**: Write failing test first, then implement
+- Add test in `tests/FrenchGuidelinesCheckerTest.php`
+- Test both error detection and fixing
+- Run `composer test` to verify
+
+### 2. Core Implementation  
+- Add logic to `processString()` method in `src/FrenchGuidelinesChecker.php`
+- Use existing constants: `self::NBSP`, `DOUBLE_PUNCTUATION`, `ELLIPSIS`, and add constants if needed
+- Follow error message pattern: `"Message describing issue: $text"`
+
+### 3. Documentation Updates
+- Mark rule as ✅ implemented in `docs/french-rules.md`
+- Update README if needed
+
+## Quality Checklist
+
+**All must pass before PR submission:**
+- [ ] TDD followed (test written first, fails, then passes)
+- [ ] All QA checks: `composer run-script qa`
+- [ ] Rule marked as ✅ in `docs/french-rules.md`
+- [ ] Manual CLI testing: `bin/check-translation test-file.po`
+
+## Acceptance Criteria
+- [ ] Test case added and passes
+- [ ] Error detection works correctly
+- [ ] Text fixing works with `--fix` flag
+- [ ] No regressions in existing functionality
+- [ ] Documentation properly updated
+- [ ] All quality checks pass
+
+## Resources
+- Check existing rules in `processString()` method for implementation patterns
+
+@claude, can you fix this issue with simple implementation, nothing more, nothing less?

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 *.mo
 *.po.bak
 
-.claude
+.claude/commands
+.claude/templates
 feature
 CLAUDE.md

--- a/docs/french-rules.md
+++ b/docs/french-rules.md
@@ -19,7 +19,7 @@
 - [x] Point-virgule (;)
 - [x] Deux points (:)
 - [x] Guillemets français fermants (»)
-- [ ] Pourcentage (%)
+- [x] Pourcentage (%)
 - [ ] Unités de mesure (25 km)
 - [ ] Monnaies (25 €)
 - [ ] Signes mathématiques (=, <, >, ~)

--- a/src/FrenchGuidelinesChecker.php
+++ b/src/FrenchGuidelinesChecker.php
@@ -9,7 +9,7 @@ use Gettext\Loader\PoLoader;
 
 class FrenchGuidelinesChecker
 {
-    private const NBSP = "\u{00A0}";
+    protected const NBSP = "\u{00A0}";
     private const ELLIPSIS = '…';
     private const DOUBLE_PUNCTUATION = ['!', '?', ':', ';', '»'];
 

--- a/src/FrenchGuidelinesChecker.php
+++ b/src/FrenchGuidelinesChecker.php
@@ -194,6 +194,12 @@ class FrenchGuidelinesChecker
             $fixed = (string) preg_replace("/etc(\.{2,3}|…)/u", 'etc.', $fixed);
         }
 
+        // Rule: Non-breaking space before percentage sign
+        if (str_contains($text, '%') && !str_contains($text, self::NBSP . '%')) {
+            $errors[] = "Espace insécable avant le signe de pourcentage : $text";
+            $fixed = (string) preg_replace('/\s*%/', self::NBSP . '%', $fixed);
+        }
+
         return ['errors' => $errors, 'fixed_string' => $fixed];
     }
 

--- a/src/FrenchGuidelinesChecker.php
+++ b/src/FrenchGuidelinesChecker.php
@@ -9,9 +9,9 @@ use Gettext\Loader\PoLoader;
 
 class FrenchGuidelinesChecker
 {
-    protected const NBSP = "\u{00A0}";
-    private const ELLIPSIS = '…';
-    private const DOUBLE_PUNCTUATION = ['!', '?', ':', ';', '»'];
+    public const NBSP = "\u{00A0}";
+    public const ELLIPSIS = '…';
+    public const DOUBLE_PUNCTUATION = ['!', '?', ':', ';', '»'];
 
     public function __construct(private ?Translator $translator = null)
     {

--- a/tests/FrenchGuidelinesCheckerTest.php
+++ b/tests/FrenchGuidelinesCheckerTest.php
@@ -345,6 +345,31 @@ class FrenchGuidelinesCheckerTest extends TestCase
         $this->assertEquals('Unknown', Translator::getLanguageName(''));
     }
 
+    public function testPercentageSpacing(): void
+    {
+        $po = <<<PO
+            msgid "The success rate is 50%"
+            msgstr "Le taux de réussite est de 50%"
+            PO;
+        $result = $this->checker->check($po);
+
+        $this->assertCount(1, $result['errors']);
+        $this->assertStringContainsString(
+            'Espace insécable avant le signe de pourcentage',
+            $result['errors'][0]
+        );
+
+        $result = $this->checker->check($po, true);
+
+        $this->assertCount(1, $result['errors']);
+        $this->assertArrayHasKey('fixed_content', $result);
+        $this->assertIsString($result['fixed_content']);
+        $this->assertStringContainsString(
+            'Le taux de réussite est de 50 %',
+            $result['fixed_content']
+        );
+    }
+
     public function testTranslateToGerman(): void
     {
         $openai = $this->createMock(\Orhanerday\OpenAi\OpenAi::class);

--- a/tests/FrenchGuidelinesCheckerTest.php
+++ b/tests/FrenchGuidelinesCheckerTest.php
@@ -365,7 +365,7 @@ class FrenchGuidelinesCheckerTest extends TestCase
         $this->assertArrayHasKey('fixed_content', $result);
         $this->assertIsString($result['fixed_content']);
         $this->assertStringContainsString(
-            'Le taux de réussite est de 50 %',
+            'Le taux de réussite est de 50' . FrenchGuidelinesChecker::NBSP . '%',
             $result['fixed_content']
         );
     }


### PR DESCRIPTION
Fixes #3

## Summary
Implemented the French typography rule that requires a non-breaking space before the percentage sign (%).

## Changes
- Added test case `testPercentageSpacing()` for the percentage rule
- Implemented the rule in `processString()` method
- Updated documentation to mark rule as implemented

## Test Plan
- [x] Test case added and passes
- [x] Error detection works correctly
- [x] Text fixing works with `--fix` flag
- [x] Documentation properly updated

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic enforcement of a non-breaking space before the percentage sign (%) in French text.
  * Users are now alerted if a non-breaking space is missing before the percentage sign, with an option to auto-correct the spacing.

* **Documentation**
  * Updated French typographic rules checklist to indicate the percentage sign spacing rule is now enforced.
  * Added a new GitHub issue template to guide contributions on French typography rules.
  * Introduced a "Definition of Done" document outlining feature completion criteria.

* **Tests**
  * Added tests to verify detection and correction of missing non-breaking spaces before the percentage sign.

* **Chores**
  * Refined `.gitignore` to better specify excluded directories.
  * Added local settings configuration to manage allowed Composer commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->